### PR TITLE
Remove duplicated style tag on hit.html

### DIFF
--- a/hit.html
+++ b/hit.html
@@ -121,7 +121,6 @@
 }
 
 </style>
-</style>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
 <script>
     $(document).ready(function(){


### PR DESCRIPTION
A duplicated style tag may make unexpected result, it may also error with some HTML parser.